### PR TITLE
Fixed issue with resources_list_with_min_and_max() returning GB and not MB and more

### DIFF
--- a/snakemake_rules/preprocessing.smk
+++ b/snakemake_rules/preprocessing.smk
@@ -27,7 +27,7 @@ def resources_list_with_min_and_max(file_name_list, attempt, mult_factor=2, mini
 	# check documentation https://snakemake.readthedocs.io/en/stable/_modules/snakemake/io.html
 	# for more info
 	try:
-		resource = int(sum([file.size for file in file_name_list]) / 1024) * attempt * mult_factor)
+		resource = int(sum([file.size for file in file_name_list]) / 1024) * attempt * mult_factor
 	# sometimes this doesn't work - not sure why...
 	except WorkflowError:
 		

--- a/snakemake_rules/preprocessing.smk
+++ b/snakemake_rules/preprocessing.smk
@@ -13,21 +13,16 @@
 import functools
 import re
 
-def multiple_dirname(path, n):
-	parent_path = os.path.dirname(path)
-	if n == 0:
-		return parent_path
-	return multiple_dirname(parent_path, n-1)
 
 # fuction to get mem_mb based on size of input files
-def resources_list_with_min_and_max(file_name_list, attempt, mult_factor=2, minimum = 100, maximum = 120000):
+def resources_list_with_min_and_max(file_name_list, attempt, mult_factor=2, minimum = 100, maximum = 128000):
 	
-	# get sum of size of files in file_name_list
+	# get sum of size of files in file_name_list in megabytes (MB)
 	# input files are instances of class snakemake.io._IOFile
 	# check documentation https://snakemake.readthedocs.io/en/stable/_modules/snakemake/io.html
 	# for more info
 	try:
-		resource = int(sum([file.size for file in file_name_list]) / 1024 / 1024) * attempt * mult_factor
+		resource = int(sum([file.size for file in file_name_list]) / 1024) * attempt * mult_factor)
 	# sometimes this doesn't work - not sure why...
 	except WorkflowError:
 		
@@ -114,8 +109,8 @@ def strip_wildcard_constraints(string_with_constraints):
 	# if we want to use these these as input to other rules, we need to strip out the commas
 	
 	string = string_with_constraints
-
-	if re.search(",.+?\}", string):
+	
+	if re.search("\{\w+,\w+\}", string):
 		string = re.sub(",.+?\}", "}", string)
 	
 	return string
@@ -170,8 +165,6 @@ rule bam_to_fastq:
 		"../envs/bwa.yml"
 	container:
 		"docker://szsctt/isling:latest"
-	resources:
-		mem_mb=lambda wildcards, attempt, input: resources_list_with_min_and_max(input, attempt)
 	shell:
 		"""
 		samtools view -b -F '0x900' {input.bam} |\
@@ -188,14 +181,14 @@ rule dedupe:
 		r2_dedup = temp("{outpath}/{dset}/dedup_reads/{samp}_2.fq")
 	params:
 		n_subs = lambda wildcards: get_value_from_df(wildcards, "dedup_subs"),
-		mem_mb = lambda wildcards, resources: max(int(resources.mem_mb * 0.8), 1000)
+		mem_mb = lambda wildcards, resources: max(int(resources.mem_mb * 2), 1000)
 	threads: cpus
 	conda:	
 		"../envs/bbmap.yml"
 	container:
 		"docker://szsctt/isling:latest"
 	resources:
-		mem_mb = lambda wildcards, attempt, input: resources_list_with_min_and_max(input, attempt, 8),
+		mem_mb = lambda wildcards, attempt, input: resources_list_with_min_and_max(input, attempt, 1),
 		time = lambda wildcards, attempt: (30, 120, 1440, 10080)[attempt - 1],
 		nodes = 1 # need this for pearcey so that job doesn't get split over multiple nodes
 	shell:

--- a/snakemake_rules/preprocessing.smk
+++ b/snakemake_rules/preprocessing.smk
@@ -114,7 +114,6 @@ def strip_wildcard_constraints(string_with_constraints):
 	# if we want to use these these as input to other rules, we need to strip out the commas
 	
 	string = string_with_constraints
-	
 	if re.search(",.+?\}", string):
 		string = re.sub(",.+?\}", "}", string)
 	

--- a/snakemake_rules/preprocessing.smk
+++ b/snakemake_rules/preprocessing.smk
@@ -13,6 +13,11 @@
 import functools
 import re
 
+def multiple_dirname(path, n):
+	parent_path = os.path.dirname(path)
+	if n == 0:
+		return parent_path
+	return multiple_dirname(parent_path, n-1)
 
 # fuction to get mem_mb based on size of input files
 def resources_list_with_min_and_max(file_name_list, attempt, mult_factor=2, minimum = 100, maximum = 128000):
@@ -110,7 +115,7 @@ def strip_wildcard_constraints(string_with_constraints):
 	
 	string = string_with_constraints
 	
-	if re.search("\{\w+,\w+\}", string):
+	if re.search(",.+?\}", string):
 		string = re.sub(",.+?\}", "}", string)
 	
 	return string
@@ -181,7 +186,7 @@ rule dedupe:
 		r2_dedup = temp("{outpath}/{dset}/dedup_reads/{samp}_2.fq")
 	params:
 		n_subs = lambda wildcards: get_value_from_df(wildcards, "dedup_subs"),
-		mem_mb = lambda wildcards, resources: max(int(resources.mem_mb * 2), 1000)
+		mem_mb = lambda wildcards, resources: max(int(resources.mem_mb * 1), 1000)
 	threads: cpus
 	conda:	
 		"../envs/bbmap.yml"


### PR DESCRIPTION
Changelog:

- Fixed issue with resources_list_with_min_and_max() returning GB and not MB
- Adjusted required resources for rule dedupe
- Removed redundant resources param in rule bam_to_fastq